### PR TITLE
Update Benchee, Meeseeks, Floki, and results

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,25 +35,51 @@ For XPath, I test both a naive solution that is closely related to the CSS solut
 ```
 $ MIX_ENV=prod mix compile
 $ MIX_ENV=prod mix run bench/wiki_links.exs
+Operating System: macOS
+CPU Information: Intel(R) Core(TM) i7-5557U CPU @ 3.10GHz
+Number of Available Cores: 4
+Available memory: 8 GB
+Elixir 1.8.1
+Erlang 21.2.4
+
+Benchmark suite executing with the following configuration:
+warmup: 3 s
+time: 9 s
+memory time: 3 s
+parallel: 1
+inputs: none specified
+Estimated total run time: 1 min
+
+
 Benchmarking Floki CSS...
 Benchmarking Meeseeks CSS...
 Benchmarking Meeseeks XPath naive...
 Benchmarking Meeseeks XPath optimized...
 
-Name                               ips        average  deviation         median
-Meeseeks CSS                     92.98       10.75 ms     ±3.33%       10.67 ms
-Meeseeks XPath optimized         85.49       11.70 ms     ±1.87%       11.67 ms
-Floki CSS                        76.99       12.99 ms     ±9.44%       12.92 ms
-Meeseeks XPath naive             71.36       14.01 ms     ±1.82%       13.96 ms
+Name                               ips        average  deviation         median         99th %
+Meeseeks CSS                     82.89       12.06 ms     ±3.30%       11.93 ms       14.05 ms
+Floki CSS                        82.85       12.07 ms     ±7.36%       12.04 ms       14.31 ms
+Meeseeks XPath optimized         69.23       14.44 ms     ±4.54%       14.45 ms       17.39 ms
+Meeseeks XPath naive             61.78       16.19 ms     ±4.10%       16.02 ms       19.00 ms
 
 Comparison:
-Meeseeks CSS                     92.98
-Meeseeks XPath optimized         85.49 - 1.09x slower
-Floki CSS                        76.99 - 1.21x slower
-Meeseeks XPath naive             71.36 - 1.30x slower
+Meeseeks CSS                     82.89
+Floki CSS                        82.85 - 1.00x slower
+Meeseeks XPath optimized         69.23 - 1.20x slower
+Meeseeks XPath naive             61.78 - 1.34x slower
+
+Memory usage statistics:
+
+Name                        Memory usage
+Meeseeks CSS                     0.77 MB
+Floki CSS                        2.92 MB - 3.79x memory usage
+Meeseeks XPath optimized         1.09 MB - 1.41x memory usage
+Meeseeks XPath naive             2.15 MB - 2.79x memory usage
+
+**All measurements for memory usage were the same**
 ```
 
-If you're going to be building a simple crawler where all you care about is searching a page for links, either Meeseeks or Floki will work, though Meeseeks tends to be a little faster.
+If you're going to be building a simple crawler where all you care about is searching a page for links, either Meeseeks or Floki will perform similarly.
 
 [Implementation](https://github.com/mischov/meeseeks_floki_bench/blob/master/lib/meeseeks_floki_bench/wiki_links.ex)
 
@@ -68,22 +94,47 @@ The test data used is 349Kb and parses to ~6,900 nodes.
 ```
 $ MIX_ENV=prod mix compile
 $ MIX_ENV=prod mix run bench/trending_js.exs
+Operating System: macOS
+CPU Information: Intel(R) Core(TM) i7-5557U CPU @ 3.10GHz
+Number of Available Cores: 4
+Available memory: 8 GB
+Elixir 1.8.1
+Erlang 21.2.4
+
+Benchmark suite executing with the following configuration:
+warmup: 3 s
+time: 9 s
+memory time: 3 s
+parallel: 1
+inputs: none specified
+Estimated total run time: 45 s
+
+
 Benchmarking Floki CSS...
 Benchmarking Meeseeks CSS ...
 Benchmarking Meeseeks XPath...
 
-Name                     ips        average  deviation         median
-Meeseeks CSS           23.73       42.15 ms     ±1.10%       42.06 ms
-Meeseeks XPath         21.64       46.22 ms     ±0.95%       46.21 ms
-Floki CSS              16.80       59.51 ms     ±2.18%       59.27 ms
+Name                     ips        average  deviation         median         99th %
+Meeseeks CSS           22.20       45.04 ms     ±4.54%       44.16 ms       52.01 ms
+Meeseeks XPath         18.45       54.21 ms     ±4.51%       53.53 ms       61.46 ms
+Floki CSS              18.23       54.86 ms     ±5.63%       53.95 ms       68.75 ms
 
 Comparison:
-Meeseeks CSS           23.73
-Meeseeks XPath         21.64 - 1.10x slower
-Floki CSS              16.80 - 1.41x slower
+Meeseeks CSS           22.20
+Meeseeks XPath         18.45 - 1.20x slower
+Floki CSS              18.23 - 1.22x slower
+
+Memory usage statistics:
+
+Name              Memory usage
+Meeseeks CSS           3.82 MB
+Meeseeks XPath         6.75 MB - 1.77x memory usage
+Floki CSS             14.69 MB - 3.84x memory usage
+
+**All measurements for memory usage were the same**
 ```
 
-Meeseeks avoids some data manipulation that Floki does, so both Meeseeks implementations come out ahead of Floki in this benchmark. If this scenario resembles your use case, it might be worth considering Meeseeks for performance reasons.
+Meeseeks avoids some data manipulation that Floki does, so the Meeseeks implementations come out equal to or ahead of Floki in this benchmark.
 
 [Implementation](https://github.com/mischov/meeseeks_floki_bench/blob/master/lib/meeseeks_floki_bench/trending_js.ex)
 

--- a/bench/parse.exs
+++ b/bench/parse.exs
@@ -1,0 +1,12 @@
+# Benchmark parsing the html from Github's list of trending Javascript repos
+
+warmup = 3
+time = 9
+
+# Test file is 349kB, and parses to ~6900 nodes
+html = File.read!("data/github_trending_js.html")
+
+Benchee.run%{
+  "Floki Parse" => fn -> Floki.parse(html) end,
+  "Meeseeks Parse " => fn -> Meeseeks.parse(html) end
+}, warmup: warmup, time: time

--- a/bench/trending_js.exs
+++ b/bench/trending_js.exs
@@ -3,8 +3,9 @@ alias MeeseeksFlokiBench.TrendingJs
 # Benchmark selecting various information from Github's list of trending
 # Javascript repos.
 
-warmup = 5
-time = 15
+warmup = 3
+time = 9
+memory_time = 3
 
 # Test file is 349kB, and parses to ~6900 nodes
 html = File.read!("data/github_trending_js.html")
@@ -13,4 +14,4 @@ Benchee.run%{
   "Floki CSS" => fn -> TrendingJs.floki_trending_js_css(html) end,
   "Meeseeks CSS " => fn -> TrendingJs.meeseeks_trending_js_css(html) end,
   "Meeseeks XPath" => fn -> TrendingJs.meeseeks_trending_js_xpath(html) end
-}, warmup: warmup, time: time
+}, warmup: warmup, time: time, memory_time: memory_time

--- a/bench/wiki_links.exs
+++ b/bench/wiki_links.exs
@@ -3,8 +3,9 @@ alias MeeseeksFlokiBench.WikiLinks
 # Benchmark selecting every link from a particular Wikipedia article to
 # other Wikipedia articles.
 
-warmup = 5
-time = 15
+warmup = 3
+time = 9
+memory_time = 3
 
 # Test file is 99kB, and parses to ~2700 nodes
 html = File.read!("data/wikipedia_hyperlink.html")
@@ -18,4 +19,4 @@ Benchee.run%{
   "Meeseeks XPath optimized" => fn ->
     WikiLinks.meeseeks_wiki_links_xpath_optimized(html)
   end
-}, warmup: warmup, time: time
+}, warmup: warmup, time: time, memory_time: memory_time

--- a/mix.exs
+++ b/mix.exs
@@ -15,9 +15,12 @@ defmodule MeeseeksFlokiBench.Mixfile do
   end
 
   defp deps do
-    [{:benchee, "~> 0.6"},
-     {:floki, "~> 0.17.1"},
-     {:html5ever, "~> 0.4.0"},
-     {:meeseeks, "~> 0.6.0"}]
+    [
+      {:benchee, "~> 0.14"},
+      {:floki, "~> 0.20.4"},
+      {:html5ever, "~> 0.7.0"},
+      {:meeseeks, "~> 0.11.0"},
+      {:rustler, "~> 0.20.0", override: true}
+    ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,11 @@
-%{"benchee": {:hex, :benchee, "0.6.0", "c2565506c621ee010e71d05f555e39a1b937e00810e284bc85463a4d4efc4b00", [:mix], [{:deep_merge, "~> 0.1", [hex: :deep_merge, optional: false]}]},
-  "deep_merge": {:hex, :deep_merge, "0.1.1", "c27866a7524a337b6a039eeb8dd4f17d458fd40fbbcb8c54661b71a22fffe846", [:mix], []},
-  "floki": {:hex, :floki, "0.17.1", "a56a54b493730910de3c7afcf353734d52a04ff2b8baa86f729bf4aa4580c0e2", [:mix], [{:mochiweb, "~> 2.15", [hex: :mochiweb, optional: false]}]},
-  "html5ever": {:hex, :html5ever, "0.4.0", "c63bf364062cbd2e6d8db057446db489da1d211d523a00a007dbf5aa3095acfc", [:mix], [{:rustler, "~> 0.9", [hex: :rustler, optional: false]}]},
-  "meeseeks": {:hex, :meeseeks, "0.6.0", "d7ad3d7efad79f892ea92f89510e21d957432b849dc697e6bce65cf89284b3f8", [:mix], [{:meeseeks_html5ever, "~> 0.5.0", [hex: :meeseeks_html5ever, optional: false]}]},
-  "meeseeks_html5ever": {:hex, :meeseeks_html5ever, "0.5.0", "746d714f1b9fa52e3130dd41f1f73174b77606a52a0a85a2247343041e98807b", [:mix], [{:rustler, "~> 0.9", [hex: :rustler, optional: false]}]},
-  "mochiweb": {:hex, :mochiweb, "2.15.0", "e1daac474df07651e5d17cc1e642c4069c7850dc4508d3db7263a0651330aacc", [:rebar3], []},
-  "rustler": {:hex, :rustler, "0.9.0", "6fa87ac78f48f70aa8ecfb6e16b8af41c398989d33de41d292b5581d6a2eeb5a", [:mix], []}}
+%{
+  "benchee": {:hex, :benchee, "0.14.0", "f771f587c48b4824b497e2a3e374f75e93ef01fc329873b089a3f5dd961b80b8", [:mix], [{:deep_merge, "~> 0.1", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm"},
+  "deep_merge": {:hex, :deep_merge, "0.2.0", "c1050fa2edf4848b9f556fba1b75afc66608a4219659e3311d9c9427b5b680b3", [:mix], [], "hexpm"},
+  "floki": {:hex, :floki, "0.20.4", "be42ac911fece24b4c72f3b5846774b6e61b83fe685c2fc9d62093277fb3bc86", [:mix], [{:html_entities, "~> 0.4.0", [hex: :html_entities, repo: "hexpm", optional: false]}, {:mochiweb, "~> 2.15", [hex: :mochiweb, repo: "hexpm", optional: false]}], "hexpm"},
+  "html5ever": {:hex, :html5ever, "0.7.0", "9f63ec1c783b2dc9f326840fcc993c01e926dbdef4e51ba1bbe5355993c258b4", [:mix], [{:rustler, "~> 0.18.0", [hex: :rustler, repo: "hexpm", optional: false]}], "hexpm"},
+  "html_entities": {:hex, :html_entities, "0.4.0", "f2fee876858cf6aaa9db608820a3209e45a087c5177332799592142b50e89a6b", [:mix], [], "hexpm"},
+  "meeseeks": {:hex, :meeseeks, "0.11.0", "479cdc4f1781cd520ff950dd06e8d529c16dbcad45586bfea6d2b6cc5d2409f0", [:mix], [{:meeseeks_html5ever, "~> 0.11.0", [hex: :meeseeks_html5ever, repo: "hexpm", optional: false]}], "hexpm"},
+  "meeseeks_html5ever": {:hex, :meeseeks_html5ever, "0.11.0", "5aaf9c895874fded42a40167841964fe30f5b73b217fb4c9e9b83f8337344d3d", [:mix], [{:rustler, "~> 0.20.0", [hex: :rustler, repo: "hexpm", optional: false]}], "hexpm"},
+  "mochiweb": {:hex, :mochiweb, "2.18.0", "eb55f1db3e6e960fac4e6db4e2db9ec3602cc9f30b86cd1481d56545c3145d2e", [:rebar3], [], "hexpm"},
+  "rustler": {:hex, :rustler, "0.20.0", "6b2cc8149700a7b1df2226dbe273ec1f9449318cad3bd3b5b68125a4cf1f438b", [:mix], [], "hexpm"},
+}


### PR DESCRIPTION
- Update Benchee to `0.14`
- Update Meeseeks to `0.11.0`
- Update Floki to `0.20.4`